### PR TITLE
Lint with accordance to `markdown-lint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,61 @@
 # I am UntrustableRus, but you can call me Rus
+
 Here's some information about me.
+
 ## Reverse Engineer
+
 I am a reverse engineer/white-hat hacker. I've reversed engineered quite a few companies:
+
 ### HQ Trivia (Admin Panel Experience & Major Vulnerability)
+
 #### HQ Trivia is a live mobile game show app, where every Thursday if you answer 12 questions presented by a live host correctly, you will split the cash prize with the other winners.
+
 ##### Major Vulnerability (January 2023)
+
 I took over the HQ Trivia app for 10 days and gave away $50 in live shows. I'm working on a medium article about this and it will be available soon.
+
 ##### Admin Panel Experience (October 2022)
+
 I was able to use the source maps of HQ Trivia's admin panel to get one running locally. I was able to see what all of the menus looked like and everything, however, I did not have a user account or anything, so I coudln't exactly see or do anything special, asides from seeing what the admin panel looks like.
+
 ### Chrome (Medium Vulnerability)
+
 #### Chrome is a browser used by over 3 billion people worldwide.
+
 Unfortunately, the vulnerability is classified as it still exists. I'll update this when Chrome releases the vulnerability publicly.
+
 ### Roblox/Trello (Admin Panel Pictures)
+
 #### Roblox is a 3D gaming platform used by millions of players each day.
-I was able to exploit a vulnerability with Trello that allowed everyone to see private images in a Trello board. I exploited this vulnerability to find images of Roblox's admin panel that were shared on their internal Trello board that was seemingly used for admin panl suggestions/bugs.
+
+I was able to exploit a vulnerability with Trello that allowed everyone to see private images in a Trello board. I exploited this vulnerability to find images of Roblox's admin panel that were shared on their internal Trello board that was seemingly used for admin panel suggestions/bugs.
+
 ### World2Build (Major Vulnerability)
+
 #### World2Build is a 3D sandbox similar to Roblox, but does not have as many players.
+
 Unfortunately, the vulnerability is classified as it still exists. I'll update this when it's patched.
+
 ### Blooket (Admin Panel Experience)
+
 #### Blooket is a live game played in school for studying, similar to GimKit and Kahoot, among others.
+
 I was able to use the source maps of Blooket's admin panel to get one running locally. I was able to see what all of the menus looked like and everything, however, I did not have a user account or anything, so I coudln't exactly see or do anything special, asides from seeing what the admin panel looks like. *(Yes, this is the same exact thing I did for HQ Trivia)*
+
 ### VocabularySpellingCity (XSS)
+
 #### VocabularySpellingCity was a learning website for teachers to assign to students. It allowed students to use the site to play games with the words that the teacher assigns.
+
 They forgot to sanitize inputs, so I was able to create a spelling set on their website will script tags and stuff like that, which would then show up on one of their pages as "recently created"
+
 ### Clouthub (Access to millions of users' data)
+
 #### Clouthub is an alt-right social media platform that promotes free speech, serving as a safe haven from censorship on other social platforms.
+
 I was able to change any and all data about my account, including verified status. I was able to set my account to be verified, set my account as a founder, and more. In addition, I was able to access the personal information of any user on the platform. I could see phone numbers, emails and more. If I was in bad faith, I could have mined all of this information and sold it on BreachForums, but of course I did the right thing and reported the vulnerability to the company. There are some more minor vulnerabiities that still exist on the site, but they are so minor I haven't bothered to report them.
+
 ### Prodigy Math Game (Privilage Escalation)
+
 #### Prodigy Math Game is a game used to teach K-12 schoolchildren arithmetic.
+
 I was able to exploit a vulnerability with emails that allowed me to close any support ticket. This is a very minor vulnerability.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I am a reverse engineer/white-hat hacker. I've reversed engineered quite a few c
 
 ### HQ Trivia (Admin Panel Experience & Major Vulnerability)
 
-#### HQ Trivia is a live mobile game show app, where every Thursday if you answer 12 questions presented by a live host correctly, you will split the cash prize with the other winners.
+#### HQ Trivia is a live mobile game show app, where every Thursday if you answer 12 questions presented by a live host correctly, you will split the cash prize with the other winners
 
 ##### Major Vulnerability (January 2023)
 
@@ -20,42 +20,42 @@ I was able to use the source maps of HQ Trivia's admin panel to get one running 
 
 ### Chrome (Medium Vulnerability)
 
-#### Chrome is a browser used by over 3 billion people worldwide.
+#### Chrome is a browser used by over 3 billion people worldwide
 
 Unfortunately, the vulnerability is classified as it still exists. I'll update this when Chrome releases the vulnerability publicly.
 
 ### Roblox/Trello (Admin Panel Pictures)
 
-#### Roblox is a 3D gaming platform used by millions of players each day.
+#### Roblox is a 3D gaming platform used by millions of players each day
 
 I was able to exploit a vulnerability with Trello that allowed everyone to see private images in a Trello board. I exploited this vulnerability to find images of Roblox's admin panel that were shared on their internal Trello board that was seemingly used for admin panel suggestions/bugs.
 
 ### World2Build (Major Vulnerability)
 
-#### World2Build is a 3D sandbox similar to Roblox, but does not have as many players.
+#### World2Build is a 3D sandbox similar to Roblox, but does not have as many players
 
 Unfortunately, the vulnerability is classified as it still exists. I'll update this when it's patched.
 
 ### Blooket (Admin Panel Experience)
 
-#### Blooket is a live game played in school for studying, similar to GimKit and Kahoot, among others.
+#### Blooket is a live game played in school for studying, similar to GimKit and Kahoot, among others
 
 I was able to use the source maps of Blooket's admin panel to get one running locally. I was able to see what all of the menus looked like and everything, however, I did not have a user account or anything, so I coudln't exactly see or do anything special, asides from seeing what the admin panel looks like. *(Yes, this is the same exact thing I did for HQ Trivia)*
 
 ### VocabularySpellingCity (XSS)
 
-#### VocabularySpellingCity was a learning website for teachers to assign to students. It allowed students to use the site to play games with the words that the teacher assigns.
+#### VocabularySpellingCity was a learning website for teachers to assign to students. It allowed students to use the site to play games with the words that the teacher assigns
 
 They forgot to sanitize inputs, so I was able to create a spelling set on their website will script tags and stuff like that, which would then show up on one of their pages as "recently created"
 
 ### Clouthub (Access to millions of users' data)
 
-#### Clouthub is an alt-right social media platform that promotes free speech, serving as a safe haven from censorship on other social platforms.
+#### Clouthub is an alt-right social media platform that promotes free speech, serving as a safe haven from censorship on other social platforms
 
 I was able to change any and all data about my account, including verified status. I was able to set my account to be verified, set my account as a founder, and more. In addition, I was able to access the personal information of any user on the platform. I could see phone numbers, emails and more. If I was in bad faith, I could have mined all of this information and sold it on BreachForums, but of course I did the right thing and reported the vulnerability to the company. There are some more minor vulnerabiities that still exist on the site, but they are so minor I haven't bothered to report them.
 
 ### Prodigy Math Game (Privilage Escalation)
 
-#### Prodigy Math Game is a game used to teach K-12 schoolchildren arithmetic.
+#### Prodigy Math Game is a game used to teach K-12 schoolchildren arithmetic
 
 I was able to exploit a vulnerability with emails that allowed me to close any support ticket. This is a very minor vulnerability.


### PR DESCRIPTION
This PR spaces out headers, fixed one typo and removes punctuation from headers, to comply with [Markdown Lint](https://github.com/DavidAnson/markdownlint)